### PR TITLE
feat: JWT 토큰 오류 시 401 error 반환

### DIFF
--- a/src/main/java/com/nhnacademy/store99/gateway/filter/AuthorizationFilter.java
+++ b/src/main/java/com/nhnacademy/store99/gateway/filter/AuthorizationFilter.java
@@ -80,13 +80,13 @@ public class AuthorizationFilter extends AbstractGatewayFilterFactory<Authorizat
             // X-USER-TOKEN 이라는 이름의 header 가 존재하는 지 확인
             if (xUserToken == null) {
                 log.debug("X-USER-TOKEN header 없음");
-                return handleUnAuthorize(exchange);
+                return handleBadRequest(exchange);
             }
 
             // 토큰이 비어 있는 지 확인
             if (xUserToken.isEmpty()) {
                 log.debug("토큰이 비어있음");
-                return handleUnAuthorize(exchange);
+                return handleBadRequest(exchange);
             }
 
             // 사용 기간이 만료 되었는 지 확인
@@ -117,12 +117,30 @@ public class AuthorizationFilter extends AbstractGatewayFilterFactory<Authorizat
 
     /**
      * 인증 실패 시 401 에러 처리
+     * <p>1. Jwt Token parsing 실패
+     * <p>2. Jwt Token 만료
+     * <p>3. userId 가 Redis 에 존재하지 않음
      *
      * @return 401_UNAUTHORIZED
      */
     private Mono<Void> handleUnAuthorize(ServerWebExchange exchange) {
         ServerHttpResponse response = exchange.getResponse();
         response.setStatusCode(HttpStatus.UNAUTHORIZED);
+
+        return response.setComplete();
+    }
+
+    /**
+     * Header 가 없거나 빈 값일 경우 400 에러 처리
+     *
+     * <p>X-USER-TOKEN header 없음
+     * <p>토큰이 비어있음
+     *
+     * @return 400_BAD_REQUEST
+     */
+    private Mono<Void> handleBadRequest(ServerWebExchange exchange) {
+        ServerHttpResponse response = exchange.getResponse();
+        response.setStatusCode(HttpStatus.BAD_REQUEST);
 
         return response.setComplete();
     }

--- a/src/main/java/com/nhnacademy/store99/gateway/util/JwtUtil.java
+++ b/src/main/java/com/nhnacademy/store99/gateway/util/JwtUtil.java
@@ -4,7 +4,6 @@ import com.nhnacademy.store99.gateway.property.JwtProperties;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jws;
-import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.io.Decoders;
@@ -105,10 +104,8 @@ public class JwtUtil {
                     .parseClaimsJws(token);
             return claimsJws.getBody().getExpiration().after(new Date());
 
-        } catch (SignatureException | MalformedJwtException e) {
-            throw new SignatureException("올바르지 않은 서명", e);
-        } catch (ExpiredJwtException e) {
-            throw new JwtException("사용 기간이 만료된 토큰", e);
+        } catch (SignatureException | MalformedJwtException | ExpiredJwtException e) {
+            return false;
         }
     }
 


### PR DESCRIPTION
# 이슈
JWT 토큰이 만료된 경우 예외처리가 적절하지 않아 500 Error 가 발생했습니다. 이로 인해 다른 요청들도 모두 수행하지 못하는 이슈가 있었습니다.

 - https://github.com/nhnacademy-be5-staff99/store99-gateway/issues/23

# 해결
JWT 토큰 만료 에러 및 서명 에러인 경우 `401 UNAUTHORIZED` 를 반환합니다.
X-USER-TOKEN header 가 없는 경우 `400 BAD_REQUEST` 를 반환합니다.

Header 가 없는 요청은 요청 자체가 잘 못 되었다고 생각이 들어 이렇게 변경했습니다.

# 결론
이제 Front 에서는 `FeignException.BadRequest`, `FeignException.Unauthorized` 를 받아 적절히 처리합니다.